### PR TITLE
Added pod order numbers in front of commander names

### DIFF
--- a/src/components/CommanderTile.tsx
+++ b/src/components/CommanderTile.tsx
@@ -149,10 +149,12 @@ export const CommanderTile = (props: CardInfoProps) => {
         <StyledTile>
           {typeof props.commanders === "string" ? (
             <StyledCardName>
+              {props.index + 1 + ". "}
               {formatNameForDisplay(props.commanders)}
             </StyledCardName>
           ) : (
             <StyledCardName>
+              {props.index + 1 + ". "}
               {formatNameForDisplay(props.commanders)}
             </StyledCardName>
           )}

--- a/src/httpProxy.js
+++ b/src/httpProxy.js
@@ -1,0 +1,39 @@
+import express from "express";
+import { createProxyMiddleware } from "http-proxy-middleware";
+
+const app = express();
+
+app.use((req, res, next) => {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader(
+    "Access-Control-Allow-Methods",
+    "GET, POST, OPTIONS, PUT, PATCH, DELETE"
+  );
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "X-Requested-With,content-type"
+  );
+  res.setHeader("Access-Control-Allow-Credentials", true);
+  next();
+});
+
+app.use(
+  "/v3/decks/all",
+  createProxyMiddleware({
+    target: "https://api2.moxfield.com",
+    changeOrigin: true,
+    pathRewrite: {
+      "^/v3/decks/all": "/v3/decks/all",
+    },
+  })
+);
+
+const PORT = 8080;
+
+app.get("/", (req, res) => {
+  res.send("Proxy server is running.");
+});
+
+app.listen(PORT, () => {
+  console.log(`Proxy server is running on http://localhost:${PORT}/`);
+});


### PR DESCRIPTION
Added pod order numbers in front of commander names:

<img width="1440" alt="CleanShot 2024-05-26 at 19 29 28@2x" src="https://github.com/Joshua-Farr/cedh-pod-simulator/assets/94776350/dc32f3d1-dc95-4e11-9ad3-c9b22190f600">
